### PR TITLE
add unbind

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,6 +77,13 @@ def test_zeros_like():
   t2j_function_test(lambda x: torch.zeros_like(x), [(2, 3)])
 
 
+def test_unbind():
+  t2j_function_test(lambda x: torch.unbind(x)[0], [(2, 3)])
+  t2j_function_test(lambda x: torch.unbind(x, dim=1)[1], [(2, 3)])
+  t2j_function_test(lambda x: x.unbind()[0], [(2, 3)])
+  t2j_function_test(lambda x: x.unbind(1)[1], [(2, 3)])
+
+
 def test_oneliners():
   t2j_function_test(lambda x: torch.pow(x, 2), [()])
   t2j_function_test(lambda x: torch.pow(x, 2), [(3,)])

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -126,6 +126,9 @@ class Torchish:
 
     return Torchish(jnp.broadcast_to(self.value, newshape))
 
+  def unbind(self, dim=0):
+    return tuple( Torchish(self.value[(slice(None),)*dim + (i,)]) for i in range(self.value.shape[dim]))
+
   # fmt: off
   def __add__(self, other): return Torchish(self.value + _coerce(other))
   def __getitem__(self, key): return Torchish(self.value.__getitem__(key))

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -126,9 +126,6 @@ class Torchish:
 
     return Torchish(jnp.broadcast_to(self.value, newshape))
 
-  def unbind(self, dim=0):
-    return tuple( Torchish(self.value[(slice(None),)*dim + (i,)]) for i in range(self.value.shape[dim]))
-
   # fmt: off
   def __add__(self, other): return Torchish(self.value + _coerce(other))
   def __getitem__(self, key): return Torchish(self.value.__getitem__(key))
@@ -297,6 +294,11 @@ def bernoulli(input, generator=None, out=None):
 @implements(torch.cat)
 def cat(tensors, dim=0):
   return jnp.concatenate([_v(x) for x in tensors], axis=dim)
+
+
+@implements(torch.unbind, Torchishify_output=False)
+def unbind(input, dim=0) -> Sequence[Torchish]:
+  return tuple(Torchish(input.value[(slice(None),) * dim + (i,)]) for i in range(input.value.shape[dim]))
 
 
 @implements(torch.empty)

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -159,6 +159,7 @@ class Torchish:
   def transpose(*args, **kwargs): return torch.transpose(*args, **kwargs)
   def view(self, *shape): return Torchish(jnp.reshape(self.value, shape))
   reshape = view
+  def unbind(*args, **kwargs): return torch.unbind(*args, **kwargs)
   # fmt: on
 
   def add_(self, other):
@@ -294,11 +295,6 @@ def bernoulli(input, generator=None, out=None):
 @implements(torch.cat)
 def cat(tensors, dim=0):
   return jnp.concatenate([_v(x) for x in tensors], axis=dim)
-
-
-@implements(torch.unbind, Torchishify_output=False)
-def unbind(input, dim=0) -> Sequence[Torchish]:
-  return tuple(Torchish(input.value[(slice(None),) * dim + (i,)]) for i in range(input.value.shape[dim]))
 
 
 @implements(torch.empty)
@@ -492,6 +488,11 @@ def tensor(data, dtype=None, device=None, requires_grad=False, pin_memory=False)
   return jnp.array(
     data.value if isinstance(data, Torchish) else data, dtype=t2j_dtype(dtype or torch.get_default_dtype())
   )
+
+
+@implements(torch.unbind, Torchishify_output=False)
+def unbind(input, dim=0) -> Sequence[Torchish]:
+  return tuple(Torchish(input.value[(slice(None),) * dim + (i,)]) for i in range(input.value.shape[dim]))
 
 
 @implements(torch.zeros)


### PR DESCRIPTION
solves the following error:

```
  File ".../.venv/lib/python3.12/site-packages/timm/layers/attention.py",
  line 73, in forward
    q, k, v = qkv.unbind(0)
             ^^^^^^^^^^^^^^
AttributeError: 'Torchish' object has no attribute 'unbind'

------------------
For simplicity, JAX has removed its internal frames from the traceback of the following exception. 
Set JAX_TRACEBACK_FILTERING=off to include these.
```