### PR TITLE
support view with dtype

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -137,6 +137,10 @@ def test_oneliners():
   t2j_function_test(lambda x: x.view((3, 4)), [(12,)])
   t2j_function_test(lambda x: x.view((3, 4)), [(4, 3)])
 
+  # view with dtype
+  t2j_function_test(lambda x: x.view(torch.bool), [(12,)])
+  t2j_function_test(lambda x: x.view(torch.int32), [(4, 3)])
+
   t2j_function_test(lambda x: x.unsqueeze(0), [(4, 3)])
   t2j_function_test(lambda x: x.unsqueeze(1), [(4, 3)])
   t2j_function_test(lambda x: x.unsqueeze(2), [(4, 3)])

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -170,10 +170,16 @@ class Torchish:
   def unsqueeze(self, dim): return Torchish(jnp.expand_dims(self.value, axis=dim))
   # fmt: on
 
-  def view(self, *shape):
-    if len(shape) == 1 and isinstance(shape[0], Sequence):
-      shape = shape[0]
-    return Torchish(jnp.reshape(self.value, shape))
+  def view(self, *shape_or_dtype):
+    if len(shape_or_dtype) == 1:
+      if isinstance(shape_or_dtype[0], Sequence):
+        return Torchish(self.value.reshape(shape_or_dtype[0]))
+      elif isinstance(dtype := shape_or_dtype[0], torch.dtype):
+        return Torchish(self.value.view(t2j_dtype(dtype)))
+      else:
+        raise ValueError(f"Tensor.view takes shape or dtype, got {shape_or_dtype[0]}")
+
+    return Torchish(jnp.reshape(self.value, shape_or_dtype))
 
   reshape = view
 


### PR DESCRIPTION
Torch's `view` is the combination of `jax.Array.reshape` & `jax.Array.view`