### PR TITLE
with torch.no_grad

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -284,3 +284,13 @@ def test_grad_on_off():
     return y + z
 
   t2j_function_test(f3, [()], atol=1e-6)
+
+  # test inplace functions
+  def f4(x):
+    # this is an effectively an identity function
+    # but with no_grad, the gradient should be zero
+    y = -x
+    with torch.no_grad():
+      return torch.nn.functional.relu(x, inplace=True) - torch.nn.functional.relu(y, inplace=True)
+
+  t2j_function_test(f4, [()], atol=1e-6)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -287,7 +287,7 @@ def test_grad_on_off():
 
   # test inplace functions
   def f4(x):
-    # this is an effectively an identity function
+    # this is effectively an identity function
     # but with no_grad, the gradient should be zero
     y = -x
     with torch.no_grad():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -234,8 +234,21 @@ def test_inplace_Tensor_methods():
   aac(vmap(t2j(f))(jnp.array([1, 2, 3])), [f(1.0), f(2.0), f(3.0)])
 
 
-def test_no_grad():
-  def f(x):
+def test_grad_on_off():
+  with torch.no_grad():
+    assert torch.is_grad_enabled() is False
+
+  with torch.enable_grad():
+    assert torch.is_grad_enabled() is True
+
+  with torch.set_grad_enabled(True):
+    assert torch.is_grad_enabled() is True
+
+  with torch.set_grad_enabled(False):
+    assert torch.is_grad_enabled() is False
+
+  # test no_grad context
+  def f1(x):
     with torch.no_grad():
       a = x * 2
     b = torch.sin(a)
@@ -244,4 +257,30 @@ def test_no_grad():
       d = torch.pow(c, 2)
     return b * c + d
 
-  t2j_function_test(f, [()], atol=1e-6)
+  t2j_function_test(f1, [()], atol=1e-6)
+
+  # test enable_grad
+  def f2(x):
+    @torch.enable_grad()
+    def doubler(x):
+      return x * 2
+
+    with torch.no_grad():
+      z = doubler(x)
+    return z
+
+  t2j_function_test(f2, [()], atol=1e-6)
+
+  # test set_grad_enabled
+  def f3(x):
+    with torch.set_grad_enabled(False):
+      with torch.set_grad_enabled(True):
+        y = torch.sin(x)
+      y = y * 2
+    with torch.set_grad_enabled(True):
+      with torch.set_grad_enabled(False):
+        z = torch.cos(x)
+      z = z * 3
+    return y + z
+
+  t2j_function_test(f3, [()], atol=1e-6)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -232,3 +232,16 @@ def test_inplace_Tensor_methods():
   t2j_function_test(f, [(3,)], atol=1e-6)
   t2j_function_test(f, [(3, 5)], atol=1e-6)
   aac(vmap(t2j(f))(jnp.array([1, 2, 3])), [f(1.0), f(2.0), f(3.0)])
+
+
+def test_no_grad():
+  def f(x):
+    with torch.no_grad():
+      a = x * 2
+    b = torch.sin(a)
+    c = torch.cos(x)
+    with torch.no_grad():
+      d = torch.pow(c, 2)
+    return b * c + d
+
+  t2j_function_test(f, [()], atol=1e-6)

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -522,7 +522,7 @@ def randperm(
 
 
 @implements(torch._C._set_grad_enabled, Torchishify_output=False)
-def set_grad_enabled(mode):
+def _set_grad_enabled(mode):
   torch._C._set_grad_enabled(mode)
 
 

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -83,14 +83,20 @@ HANDLED_FUNCTIONS = {}
 
 class Torchish:
   def __init__(self, value):
+    self.value = value
+
+  @property
+  def value(self):
+    return self._value
+
+  @value.setter
+  def value(self, val):
     # See https://github.com/google/jax/issues/2115 re `isinstance(value, jnp.ndarray)`.
-    assert isinstance(value, jnp.ndarray) or isinstance(value, int) or isinstance(value, float), (
-      f"Tried to create Torchish with unsupported type: {type(value)}"
+    assert isinstance(val, jnp.ndarray) or isinstance(val, int) or isinstance(val, float), (
+      f"Tried to create Torchish with unsupported type: {type(val)}"
     )
     global _GRAD_ENABLED
-    if not _GRAD_ENABLED:
-      value = jax.lax.stop_gradient(value)
-    self.value = value
+    self._value = val if _GRAD_ENABLED else jax.lax.stop_gradient(val)
 
   # In order for PyTorch to accept an object as one of its own and allow dynamic dispatch it must either subclass
   # `torch.Tensor` or have a `__torch_function__` method. We opt to take the method route. Dispatch logic is handled in


### PR DESCRIPTION
When using `torch.no_grad`, an error is raised complaining about `torch._C.set_grad_enabled` is not implemented for `Torchish`.

This PR added a global variable to track whether gradient is enabled. Any new `Torchish` element created under the `no_grad` context will have its `.value` wrapped with `lax.stop_gradient`.