### PR TITLE
Use dlpack for tensor export again, as referenced issue is resolved

### DIFF
--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -47,3 +47,33 @@ def test_j2t_dtypes():
   assert j2t(jnp.dtype("complex64")) == torch.complex64
   assert j2t(jnp.dtype("complex128")) == torch.complex128
   assert j2t(jnp.dtype("bfloat16")) == torch.bfloat16
+
+
+def test_t2j_array_conversion():
+  assert t2j(torch.tensor(0.0, dtype=torch.float16)).dtype == jnp.float16
+  assert t2j(torch.tensor(0.0, dtype=torch.float32)).dtype == jnp.float32
+  # assert t2j(torch.tensor(0.0, dtype=torch.float64)).dtype == jnp.float64  # requires jax_enable_x64
+  assert t2j(torch.tensor(0, dtype=torch.int8)).dtype == jnp.int8
+  assert t2j(torch.tensor(0, dtype=torch.int16)).dtype == jnp.int16
+  assert t2j(torch.tensor(0, dtype=torch.int32)).dtype == jnp.int32
+  # assert t2j(torch.tensor(0, dtype=torch.int64)).dtype == jnp.int64  # requires jax_enable_x64
+  assert t2j(torch.tensor(0, dtype=torch.uint8)).dtype == jnp.uint8
+  assert t2j(torch.tensor(False, dtype=torch.bool)).dtype == jnp.bool_
+  assert t2j(torch.tensor(0.0, dtype=torch.complex64)).dtype == jnp.complex64
+  # assert t2j(torch.tensor(0.0, dtype=torch.complex128)).dtype == jnp.complex128  # requires jax_enable_x64
+  assert t2j(torch.tensor(0.0, dtype=torch.bfloat16)).dtype == jnp.bfloat16
+
+
+def test_j2t_array_conversion():
+  assert j2t(jnp.array(0.0, dtype=jnp.float16)).dtype == torch.float16
+  assert j2t(jnp.array(0.0, dtype=jnp.float32)).dtype == torch.float32
+  # assert j2t(jnp.array(0.0, dtype=jnp.float64)).dtype == torch.float64  # requires jax_enable_x64
+  assert j2t(jnp.array(0, dtype=jnp.int8)).dtype == torch.int8
+  assert j2t(jnp.array(0, dtype=jnp.int16)).dtype == torch.int16
+  assert j2t(jnp.array(0, dtype=jnp.int32)).dtype == torch.int32
+  # assert j2t(jnp.array(0, dtype=jnp.int64)).dtype == torch.int64  # requires jax_enable_x64
+  assert j2t(jnp.array(0, dtype=jnp.uint8)).dtype == torch.uint8
+  assert j2t(jnp.array(False, dtype=jnp.bool_)).dtype == torch.bool
+  assert j2t(jnp.array(0.0, dtype=jnp.complex64)).dtype == torch.complex64
+  # assert j2t(jnp.array(0.0, dtype=jnp.complex128)).dtype == torch.complex128  # requires jax_enable_x64
+  assert j2t(jnp.array(0.0, dtype=jnp.bfloat16)).dtype == torch.bfloat16

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -42,34 +42,25 @@ def RngPooperContext(value: RngPooper | None):
 
 
 def t2j_array(torch_array):
-  # NOTE: We are resorting to the copying, non-dlpack implementation until https://github.com/jax-ml/jax/issues/25066 is
-  # resolved. Unfortunate but necessary.
-
   # Using dlpack here causes segfaults on eg `t2j(lambda x: torch.Tensor([3.0]) * x)(jnp.array([0.0]))` when we use
   # `torch.func.functionalize` in `t2j_function`. For now, we're avoiding `torch.func.functionalize`, but something to
   # be wary of in the future.
 
   # RuntimeError: Can't export tensors that require gradient, use tensor.detach()
-  # torch_array = torch_array.detach()
+  torch_array = torch_array.detach()
 
   # See https://github.com/google/jax/issues/8082.
   # torch_array = torch_array.contiguous()
 
-  # At some point between 0.4.28 and 0.4.33 from_dlpack introduced a new
-  # deprecation notice:
-  #
-  #   DeprecationWarning: Calling from_dlpack with a DLPack tensor is deprecated. The argument to from_dlpack should be an array from another framework that implements the __dlpack__ protocol.
-  #
-  # Very well, PyTorch arrays implement the __dlpack__ protocol, so no need to convert them to dlpack first.
-  # return jax.dlpack.from_dlpack(torch_array)
+  return jax.dlpack.from_dlpack(torch_array)
 
   # Alternative, but copying implementation:
   # Note FunctionalTensor.numpy() returns incorrect results, preventing us from using torch.func.functionalize.
-  return jnp.array(torch_array.numpy(force=True))
+  # return jnp.array(torch_array.numpy(force=True))
 
 
 def j2t_array(jax_array):
-  return torch.utils.dlpack.from_dlpack(jax.dlpack.to_dlpack(jax_array))
+  return torch.utils.dlpack.from_dlpack(jax_array)
 
   # Alternative, but copying implementation:
   # return torch.from_numpy(jax_array.asnumpy())


### PR DESCRIPTION
Upstream issue resolved, so we can use the non-copying export.