### PR TITLE
Add torch.scatter

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,9 +1,10 @@
 from functools import partial
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 import torch
-from jax import grad, jit, vmap
+from jax import grad, jit, random, vmap
 
 from torch2jax import t2j
 
@@ -247,6 +248,59 @@ def test_oneliners():
 
   t2j_function_test(torch.abs, [(3,)], tests=fbmo)
   t2j_function_test(lambda x: (x > 0.0).float(), [(3,)], tests=fb)
+
+
+def test_scatter():
+  # scatter
+  index = np.array([[0, 1, 2, 0, 2], [1, 0, 0, 2, 1]], dtype=np.int64)
+  samplers = [random.normal, lambda key, shape: index, random.normal]
+  tests = [forward_test, partial(backward_test, argnums=(0, 2))]
+  t2j_function_test(
+    lambda input, index, src: torch.scatter(input, 0, index, src),
+    [(3, 5), (2, 5), (2, 5)],
+    samplers=samplers,
+    atol=1e-6,
+    tests=tests,
+  )
+  # Disable gradient testing when index.shape != src.shape
+  # This is an existing problem of pytorch https://github.com/pytorch/pytorch/issues/27614
+  index = np.array([[0, 1, 2, 0, 2]], dtype=np.int64)
+  samplers = [random.normal, lambda key, shape: index, random.normal]
+  tests = [forward_test]
+  t2j_function_test(
+    lambda input, index, src: torch.scatter(input, 0, index, src),
+    [(3, 5), (1, 5), (2, 5)],
+    samplers=samplers,
+    atol=1e-6,
+    tests=tests,
+  )
+  index = np.array([[0, 1, 2, 0]], dtype=np.int64)
+  samplers = [random.normal, lambda key, shape: index, random.normal]
+  t2j_function_test(
+    lambda input, index, src: torch.scatter(input, 0, index, src),
+    [(3, 5), (1, 4), (2, 5)],
+    samplers=samplers,
+    atol=1e-6,
+    tests=tests,
+  )
+  index = np.array([[4, 2, 3], [3, 0, 4]], dtype=np.int64)
+  samplers = [random.normal, lambda key, shape: index, random.normal]
+  t2j_function_test(
+    lambda input, index, src: torch.scatter(input, 1, index, src),
+    [(3, 5), (2, 3), (3, 5)],
+    samplers=samplers,
+    atol=1e-6,
+    tests=tests,
+  )
+  index = np.array([[4, 2, 3], [3, 0, 4], [0, 1, 2]], dtype=np.int64)
+  samplers = [random.normal, lambda key, shape: index, random.normal]
+  t2j_function_test(
+    lambda input, index, src: torch.scatter(input, 1, index, src),
+    [(3, 5), (3, 3), (3, 5)],
+    samplers=samplers,
+    atol=1e-6,
+    tests=tests,
+  )
 
 
 def test_Tensor():

--- a/torch2jax/__init__.py
+++ b/torch2jax/__init__.py
@@ -87,14 +87,10 @@ class Torchish:
   @value.setter
   def value(self, val):
     # See https://github.com/google/jax/issues/2115 re `isinstance(value, jnp.ndarray)`.
-    if isinstance(val, jnp.ndarray):
-      self._value = val if torch.is_grad_enabled() else jax.lax.stop_gradient(val)
-    elif isinstance(val, (np.ndarray, int, float)):
-      # as jax is transparent to np.ndarray, we want the t2j functions to work on np.ndarray as well.
-      # stop_gradient doesn't affect np array or constants
-      self._value = val
-    else:
-      raise TypeError(f"Tried to create Torchish with unsupported type: {type(val)}")
+    assert isinstance(val, jnp.ndarray) or isinstance(val, (np.ndarray, int, float)), (
+      f"Tried to create Torchish with unsupported type: {type(val)}"
+    )
+    self._value = val if torch.is_grad_enabled() else jax.lax.stop_gradient(val)
 
   # In order for PyTorch to accept an object as one of its own and allow dynamic dispatch it must either subclass
   # `torch.Tensor` or have a `__torch_function__` method. We opt to take the method route. Dispatch logic is handled in


### PR DESCRIPTION
- Aligned with the forward behavior of `torch.scatter`.
- Backward only works for `index.shape == src.shape`, due to torch's own problem.
- Add support to pass `np.array` directly for testing, because `torch` requests `int64` for the index.
- Also add support for `Torchish` to take `np.ndarray` as per our discussion #23.